### PR TITLE
Gamefixes4 2021

### DIFF
--- a/components/round.js
+++ b/components/round.js
@@ -8,7 +8,7 @@ export default function Round(props){
       <div class="text-center">
         <div style={{borderWidth: 12}} class="border-black px-12 inline-block bg-gradient-to-tr
           my-10 from-blue-900 to-blue-500">
-          <p class="text-white"style={{textShadow: "1px 2px 4px black", fontSize: 72, fontWeight: 600}}>{props.game.point_tracker}</p>
+          <p class="text-white"style={{textShadow: "1px 2px 4px black", fontSize: 72, fontWeight: 600}}>{props.game.point_tracker[props.game.round]}</p>
         </div>
         <div class="my-5 flex flex-row justify-center">
           <p class="text-end text-3xl ">{round.question}</p>

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -3,6 +3,7 @@ import "tailwindcss/tailwind.css";
 
 export default function Admin(props){
   const [game, setGame] = useState({})
+  const [pointsGivin, setPointsGivin] = useState({state: false, color:"bg-green-200", textColor:"text-black"})
   const ws = useRef(null)
   useEffect(() => {
     ws.current = new WebSocket('ws://localhost:8080');
@@ -93,23 +94,42 @@ export default function Admin(props){
           <div class="px-10 py-5">
           <p class="text-black text-opacity-50 ">"If the title looks wrong refresh /game window"</p>
           </div>
-          <div class="flex flex-row px-10 py-1">
-            <p class="flex-grow text-2xl">Team 1 name: {game.teams[0].name}</p>
-            <p class="flex-grow text-2xl">points: {game.teams[0].points} </p>
+          <div class="flex flex-row space-x-10 px-10 py-1">
+            <p class="text-2xl">Team 1 name:</p>
             <input class="border-4 rounded" onChange={(e)=>{
               game.teams[0].name = e.target.value
               setGame(prv => ({ ...prv }));
               ws.current.send(JSON.stringify({action: "data", data: game}))
             }} placeholder="Team Name"></input>
+            <div class="flex flex-row">
+              <p class="text-2xl">points:</p>
+              <input type="number" min="0" required class="border-4 rounded" onChange={(e)=>{
+                let number = parseInt(e.target.value)
+                console.log(number)
+                isNaN(number)? number = 0: null
+                game.teams[0].points = number
+                setGame(prv => ({ ...prv }));
+                ws.current.send(JSON.stringify({action: "data", data: game}))
+              }} value={game.teams[0].points}></input>
+            </div>
           </div>
-          <div class="flex flex-row px-10 py-1">
-            <p class="flex-grow text-2xl">Team 2 name: {game.teams[1].name}</p>
-            <p class="flex-grow text-2xl">points: {game.teams[1].points} </p>
+          <div class="flex flex-row space-x-10 px-10 py-1">
+            <p class="text-2xl">Team 2 name:</p>
             <input class="border-4 rounded" onChange={(e)=>{
               game.teams[1].name = e.target.value
               setGame(prv => ({ ...prv }));
               ws.current.send(JSON.stringify({action: "data", data: game}))
             }} placeholder="Team Name"></input>
+            <div class="flex flex-row">
+              <p class="text-2xl">points:</p>
+              <input type="number" min="0" required class="border-4 rounded" onChange={(e)=>{
+                let number = parseInt(e.target.value)
+                isNaN(number)? number = 0: null
+                game.teams[1].points = number
+                setGame(prv => ({ ...prv }));
+                ws.current.send(JSON.stringify({action: "data", data: game}))
+              }} value={game.teams[1].points}></input>
+            </div>
           </div>
         </div>
         <p class="text-4xl text-center pt-5"> Current Screen: {current_screen}</p>
@@ -120,7 +140,6 @@ export default function Admin(props){
               <h2 class="text-2xl p-5">Controls</h2>
 
               <button class="border-4 rounded-lg p-2" onClick={() => {
-                game.point_tracker = 0
                 game.title = false
                 game.is_final_round = false
                 game.is_final_second = false
@@ -128,12 +147,12 @@ export default function Admin(props){
                 setGame(prv => ({
                   ...prv
                 }))
+                setPointsGivin({state: false, color:"bg-green-200", textColor: "text-black"})
                 ws.current.send(JSON.stringify({action: "data", data: game}))
               }}>start round 1</button>
 
               <button class="border-4 rounded-lg p-2" onClick={() => {
                 game.title = false
-                game.point_tracker = 0
                 game.is_final_round = false
                 game.is_final_second = false
                 game.teams[0].mistakes = 0
@@ -142,6 +161,7 @@ export default function Admin(props){
                   game.round = game.round + 1
                 }
                 setGame(prv => ({ ...prv }))
+                setPointsGivin({state: false, color:"bg-green-200", textColor: "text-black"})
                 console.log(game.round)
                 ws.current.send(JSON.stringify({action: "data", data: game}))
               }}>next round</button>
@@ -152,9 +172,9 @@ export default function Admin(props){
                 game.is_final_second = false
                 game.teams[0].mistakes = 0
                 game.teams[1].mistakes = 0
-                game.title =false
-                game.point_tracker = 0
+                game.title = false
                 setGame(prv => ({ ...prv }))
+                setPointsGivin({state: false, color:"bg-green-200", textColor: "text-black"})
                 ws.current.send(JSON.stringify({action: "data", data: game}))
               }}>
                 {game.rounds.map(( key, index ) =>
@@ -167,7 +187,6 @@ export default function Admin(props){
               }}>title card</button>
 
               <button class="border-4 rounded-lg p-2" onClick={() => {
-                game.point_tracker = 0
                 game.title = false
                 game.is_final_round = true
                 setGame(prv => ({ ...prv }))
@@ -175,15 +194,19 @@ export default function Admin(props){
                 ws.current.send(JSON.stringify({action: "set_timer", data: game.final_round_timers[0]}))
               }}>final round</button>
 
-              <button class="border-4 bg-green-200 rounded-lg p-2" onClick={() =>{
-                game.teams[0].points=game.point_tracker + game.teams[0].points
-                game.point_tracker = 0
+              <button disabled={pointsGivin.state} 
+                class={`border-4 ${pointsGivin.color} rounded-lg p-2 ${pointsGivin.textColor}`}
+                onClick={() =>{
+                game.teams[0].points=game.point_tracker[game.round] + game.teams[0].points
+                setPointsGivin({state: true, color:"bg-black-200", textColor: "text-gray-300"})
                 setGame(prv => ({ ...prv }))
                 ws.current.send(JSON.stringify({action: "data", data: game}))
               }}>Team 1: {game.teams[0].name} gets points</button>
-              <button class="border-4 bg-green-200 rounded-lg p-2" onClick={() =>{
-                game.teams[1].points=game.point_tracker + game.teams[1].points
-                game.point_tracker = 0
+              <button disabled={pointsGivin.state} 
+                class={`border-4 ${pointsGivin.color} rounded-lg p-2 ${pointsGivin.textColor}`}
+                onClick={() =>{
+                game.teams[1].points=game.point_tracker[game.round] + game.teams[1].points
+                setPointsGivin({state: true, color:"bg-black-200", textColor: "text-gray-300"})
                 setGame(prv => ({ ...prv }))
                 ws.current.send(JSON.stringify({action: "data", data: game}))
               }}>Team 2: {game.teams[1].name} gets points</button>
@@ -218,7 +241,7 @@ export default function Admin(props){
                   </div>
                   <div class="flex flex-row items-center space-x-5 justify-center pb-2">
                     <h3 class="text-xl">Multiplier {current_round.multiply}x</h3>
-                    <h3 class="text-xl">Point Tracker: {game.point_tracker}</h3>
+                    <h3 class="text-xl">Point Tracker: {game.point_tracker[game.round]}</h3>
                   </div>
                 </div>
                 <div class=" text-white rounded border-4 grid grid-rows-4 grid-flow-col  p-3 mx-10 mb-10 mt-5 gap-3 ">
@@ -229,11 +252,11 @@ export default function Admin(props){
                       setGame(prv => ({ ...prv }))
 
                       if(x.trig){
-                        game.point_tracker = game.point_tracker + x.pnt * current_round.multiply
+                        game.point_tracker[game.round] = game.point_tracker[game.round] + x.pnt * current_round.multiply
                         setGame(prv => ({ ...prv }))
                         ws.current.send(JSON.stringify({action: "reveal"}))
                       }else{
-                        game.point_tracker = game.point_tracker - x.pnt * current_round.multiply
+                        game.point_tracker[game.round] = game.point_tracker[game.round] - x.pnt * current_round.multiply
                         setGame(prv => ({ ...prv }))
                       }
                       ws.current.send(JSON.stringify({action: "data", data: game}))

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -18,6 +18,8 @@ export default function Admin(props){
       } else if(json.action === "data"){
         setGame(json.data)
       }
+      // TODO if json.action === "error" throw up a visual error on the admin console
+
     };
   }, [])
 
@@ -59,7 +61,7 @@ export default function Admin(props){
                     reader.onload = function (evt) {
                       let data = JSON.parse(evt.target.result)
                       console.debug(data)
-                      // TODO some error checking for valid game data
+                      // TODO some error checking for invalid game data
                       ws.current.send(JSON.stringify({
                         action: "load_game", data: data
                       }))

--- a/pages/new.js
+++ b/pages/new.js
@@ -52,7 +52,7 @@ export default function CreateGame(props){
                   setGame(prv => ({ ...prv }));
                 }}
               />
-              <input type="number" class="p-2 border-2" value={r.multiply} placeholder="multiplier"
+              <input type="number" min="1" class="p-2 border-2" value={r.multiply} placeholder="multiplier"
                 onChange={e => {
                   let value = parseInt(e.target.value)
                   if(value === 0 ){
@@ -72,7 +72,7 @@ export default function CreateGame(props){
                     setGame(prv => ({ ...prv }));
                   }}
                 />
-                <input type="number" class="p-2 border-2" value={a.pnt} placeholder="points"
+                <input type="number" min="0" class="p-2 border-2" value={a.pnt} placeholder="points"
                   onChange={e => {
                     a.pnt = parseInt(e.target.value)
                     setGame(prv => ({ ...prv }));
@@ -123,7 +123,7 @@ export default function CreateGame(props){
           <p class="text-3xl" >Fast Money </p>
           <div>
           <p class="text-black text-opacity-50" >timer 1</p>
-          <input type="number" class="p-2 border-2" value={game.final_round_timers[0]} placeholder="timer 1"
+          <input type="number" min="0" class="p-2 border-2" value={game.final_round_timers[0]} placeholder="timer 1"
             onChange={e => {
               game.final_round_timers[0] = parseInt(e.target.value)
               setGame(prv => ({ ...prv }));
@@ -132,7 +132,7 @@ export default function CreateGame(props){
           </div>
           <div>
           <p class="text-black text-opacity-50" >timer 2</p>
-          <input type="number" class="p-2 border-2" value={game.final_round_timers[1]} placeholder="timer 2"
+          <input type="number" min="0" class="p-2 border-2" value={game.final_round_timers[1]} placeholder="timer 2"
             onChange={e => {
               game.final_round_timers[1] = parseInt(e.target.value)
               setGame(prv => ({ ...prv }));
@@ -158,7 +158,7 @@ export default function CreateGame(props){
                     setGame(prv => ({ ...prv }));
                   }}
                 />
-                <input type="number" class="p-2 border-2" value={a[1]} placeholder="points"
+                <input type="number" min="0" class="p-2 border-2" value={a[1]} placeholder="points"
                   onChange={e => {
                     a[1] = parseInt(e.target.value)
                     setGame(prv => ({ ...prv }));

--- a/server.js
+++ b/server.js
@@ -53,7 +53,6 @@ wss.on('connection', function connection(ws) {
       process.stdout.write(".");
       message = JSON.parse(message)
       if(message.action === "load_game"){
-        console.log(game_copy)
         game_copy.teams[0].points = 0
         game_copy.teams[1].points = 0
         game_copy.round = 0

--- a/server.js
+++ b/server.js
@@ -30,7 +30,7 @@ let game = {
   ],
   title: true,
   title_text: "Change Me",
-  point_tracker: 0,
+  point_tracker: [],
   is_final_round: false,
   is_final_second: false,
   hide_first_round: true,
@@ -60,6 +60,7 @@ wss.on('connection', function connection(ws) {
         game_copy.rounds = message.data.rounds
         game_copy.final_round = message.data.final_round
         game_copy.final_round_timers = message.data.final_round_timers
+        game_copy.point_tracker = new Array(message.data.rounds.length).fill(0);
         wss.broadcast(JSON.stringify(game_copy));
       }else if (message.action === "data"){
         game_copy = message.data

--- a/server.js
+++ b/server.js
@@ -49,17 +49,28 @@ wss.broadcast = function(data) {
 
 wss.on('connection', function connection(ws) {
   ws.on('message', function incoming(message) {
-    process.stdout.write(".");
-    message = JSON.parse(message)
-    if(message.action === "load_game"){
-      game_copy = JSON.parse(JSON.stringify(game)); 
-      game_copy.rounds = message.data.rounds
-      game_copy.final_round = message.data.final_round
-      game_copy.final_round_timers = message.data.final_round_timers
-      wss.broadcast(JSON.stringify(game_copy));
-    }else{
-      game_copy = message
-      wss.broadcast(JSON.stringify(game_copy));
+    try{
+      process.stdout.write(".");
+      message = JSON.parse(message)
+      if(message.action === "load_game"){
+        console.log(game_copy)
+        game_copy.teams[0].points = 0
+        game_copy.teams[1].points = 0
+        game_copy.round = 0
+        game_copy.title = true
+        game_copy.rounds = message.data.rounds
+        game_copy.final_round = message.data.final_round
+        game_copy.final_round_timers = message.data.final_round_timers
+        wss.broadcast(JSON.stringify(game_copy));
+      }else if (message.action === "data"){
+        game_copy = message.data
+        wss.broadcast(JSON.stringify(game_copy));
+      }
+      else{
+        wss.broadcast(JSON.stringify(message));
+      }
+    }catch(e){
+      console.error("Error in processing socket message: ", e)
     }
   });
 


### PR DESCRIPTION
Fixes: 
- misc game actions don't overwrite the game like "mistake"
- load game no longer resets team names and title.
- game creator number input can no longer go into negative.
- point tracker is round-based and allows you to better go to previous round if you need it
  - extra saftey features for this point tracker. "give points" buttons now prevent multiple accidental clicks on the same round. 
  - team points on /admin are inputs now and can be changed if you need to fix a problem while playing.