### PR TITLE
New settings for admin. Styling for fast money questions

### DIFF
--- a/components/admin.js
+++ b/components/admin.js
@@ -641,6 +641,7 @@ export default function Admin(props) {
                           }
                           current_round.multiply = value;
                           props.setGame((prv) => ({ ...prv }));
+                          send({ action: "data", data: game });
                         }}
                       />
                     </div>

--- a/components/admin.js
+++ b/components/admin.js
@@ -422,6 +422,28 @@ export default function Admin(props) {
             </div>
           </div>
         </div>
+        {/* ADMIN CONTROLS */}
+        <div class="pt-5">
+          <p class="text-2xl">{t("settings")}</p>
+          <div class="grid grid-cols-3 gap-5 px-12 justify-items-start">
+            {/* Hide questions to players */}
+            <div>
+              <p class="text-m">{t("Hide question to players")}:</p>
+              <div class="w-80 flex-row items-center col-span-2">
+                <input
+                  class="rounded w-60"
+                  onChange={(e) => {
+                    game.settings.hide_questions = e.target.checked;
+                    props.setGame((prv) => ({ ...prv }));
+                    send({ action: "data", data: game });
+                  }}
+                  type="checkbox"
+                ></input>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* SHOW ERRORS TO ADMIN */}
         {error !== "" ? <p class="text-2xl text-red-700">{error}</p> : null}
         {game.rounds == null ? (
           <p class="text-2xl text-center py-20 text-black text-opacity-50">
@@ -587,9 +609,29 @@ export default function Admin(props) {
                     <h3 class="text-2xl flex-grow">
                       {t("number", { count: game.point_tracker[game.round] })}
                     </h3>
-                    <h3 class="text-xl">
-                      x{t("number", { count: current_round.multiply })}
-                    </h3>
+                    <div class="flex flex-row items-center space-x-5">
+                      <h3 class="text-xl">{t("multiplier")}: </h3>
+                      <div class="flex flex-row space-x-2">
+                        <h3 class="text-3xl">
+                          x
+                        </h3>
+                        <input
+                          type="number"
+                          min="1"
+                          class="p-2 border-2"
+                          value={current_round.multiply}
+                          placeholder={t("multiplier")}
+                          onChange={(e) => {
+                            let value = parseInt(e.target.value);
+                            if (value === 0) {
+                              value = 1;
+                            }
+                            current_round.multiply = value;
+                            props.setGame((prv) => ({ ...prv }));
+                          }}
+                        />
+                      </div>
+                    </div>
                   </div>
                 </div>
 

--- a/components/admin.js
+++ b/components/admin.js
@@ -9,7 +9,7 @@ function debounce(callback, wait = 400) {
   let timeout;
   return (...args) => {
     clearTimeout(timeout);
-    timeout = setTimeout(function() {
+    timeout = setTimeout(function () {
       callback.apply(this, args);
     }, wait);
   };
@@ -321,13 +321,13 @@ export default function Admin(props) {
                       if (file) {
                         var reader = new FileReader();
                         reader.readAsText(file, "utf-8");
-                        reader.onload = function(evt) {
+                        reader.onload = function (evt) {
                           let data = JSON.parse(evt.target.result);
                           console.debug(data);
                           // TODO some error checking for invalid game data
                           send({ action: "load_game", data: data });
                         };
-                        reader.onerror = function(evt) {
+                        reader.onerror = function (evt) {
                           console.error("error reading file");
                         };
                       }
@@ -423,24 +423,21 @@ export default function Admin(props) {
           </div>
         </div>
         {/* ADMIN CONTROLS */}
-        <div class="pt-5">
-          <p class="text-2xl">{t("settings")}</p>
-          <div class="grid grid-cols-3 gap-5 px-12 justify-items-start">
-            {/* Hide questions to players */}
-            <div>
-              <p class="text-m">{t("Hide question to players")}:</p>
-              <div class="w-80 flex-row items-center col-span-2">
-                <input
-                  class="rounded w-60"
-                  onChange={(e) => {
-                    game.settings.hide_questions = e.target.checked;
-                    props.setGame((prv) => ({ ...prv }));
-                    send({ action: "data", data: game });
-                  }}
-                  type="checkbox"
-                ></input>
-              </div>
-            </div>
+        <div class="flex flex-col">
+          <p class="text-2xl capitalize">{t("settings")}</p>
+          {/* Hide questions to players */}
+          <div class="flow flex-row space-x-5">
+            <p class="text-m normal-case">{t("Hide questions to players")}:</p>
+            <input
+              class="w-4 h-4 rounded"
+              checked={game.settings.hide_questions}
+              onChange={(e) => {
+                game.settings.hide_questions = e.target.checked;
+                props.setGame((prv) => ({ ...prv }));
+                send({ action: "data", data: game });
+              }}
+              type="checkbox"
+            ></input>
           </div>
         </div>
         {/* SHOW ERRORS TO ADMIN */}
@@ -600,37 +597,35 @@ export default function Admin(props) {
             {!game.is_final_round ? (
               // GAME BOARD CONTROLS
               <div>
-                <div class="flex flex-row justify-between space-x-5 px-10 items-center pt-5">
+                <div class="flex flex-col space-y-2 px-10 pt-5">
                   {/* QUESTION */}
                   <p class="text-3xl font-bold">{current_round.question}</p>
                   {/* POINT TRACKER */}
-                  <div class="flex flex-row border-4 p-2 items-center space-x-5">
-                    <h3 class="text-xl">{t("Points")}: </h3>
-                    <h3 class="text-2xl flex-grow">
-                      {t("number", { count: game.point_tracker[game.round] })}
-                    </h3>
-                    <div class="flex flex-row items-center space-x-5">
+                  <div class="flex flex-row border-4 p-2 space-x-5 items-center justify-between">
+                    <div class="flex flex-row space-x-5 items-center">
+                      <h3 class="text-xl">{t("Points")}: </h3>
+                      <h3 class="text-2xl flex-grow">
+                        {t("number", { count: game.point_tracker[game.round] })}
+                      </h3>
+                    </div>
+                    <div class="flex flex-row space-x-2 items-center">
                       <h3 class="text-xl">{t("multiplier")}: </h3>
-                      <div class="flex flex-row space-x-2">
-                        <h3 class="text-3xl">
-                          x
-                        </h3>
-                        <input
-                          type="number"
-                          min="1"
-                          class="p-2 border-2"
-                          value={current_round.multiply}
-                          placeholder={t("multiplier")}
-                          onChange={(e) => {
-                            let value = parseInt(e.target.value);
-                            if (value === 0) {
-                              value = 1;
-                            }
-                            current_round.multiply = value;
-                            props.setGame((prv) => ({ ...prv }));
-                          }}
-                        />
-                      </div>
+                      <h3 class="text-2xl">x</h3>
+                      <input
+                        type="number"
+                        min="1"
+                        class="p-1 border-2 w-24"
+                        value={current_round.multiply}
+                        placeholder={t("multiplier")}
+                        onChange={(e) => {
+                          let value = parseInt(e.target.value);
+                          if (value === 0) {
+                            value = 1;
+                          }
+                          current_round.multiply = value;
+                          props.setGame((prv) => ({ ...prv }));
+                        }}
+                      />
                     </div>
                   </div>
                 </div>
@@ -639,8 +634,9 @@ export default function Admin(props) {
                 <div class=" text-white rounded border-4 grid grid-rows-4 grid-flow-col  p-3 mx-10 mt-5 gap-3 ">
                   {current_round.answers.map((x) => (
                     <div
-                      class={`${x.trig ? "bg-gray-600" : "bg-blue-600"
-                        } font-extrabold uppercase rounded border-2 text-2xl rounded `}
+                      class={`${
+                        x.trig ? "bg-gray-600" : "bg-blue-600"
+                      } font-extrabold uppercase rounded border-2 text-2xl rounded `}
                     >
                       <button
                         class="flex flex-row p-5 justify-center min-h-full items-center min-w-full"

--- a/components/admin.js
+++ b/components/admin.js
@@ -9,7 +9,7 @@ function debounce(callback, wait = 400) {
   let timeout;
   return (...args) => {
     clearTimeout(timeout);
-    timeout = setTimeout(function () {
+    timeout = setTimeout(function() {
       callback.apply(this, args);
     }, wait);
   };
@@ -321,13 +321,13 @@ export default function Admin(props) {
                       if (file) {
                         var reader = new FileReader();
                         reader.readAsText(file, "utf-8");
-                        reader.onload = function (evt) {
+                        reader.onload = function(evt) {
                           let data = JSON.parse(evt.target.result);
                           console.debug(data);
                           // TODO some error checking for invalid game data
                           send({ action: "load_game", data: data });
                         };
-                        reader.onerror = function (evt) {
+                        reader.onerror = function(evt) {
                           console.error("error reading file");
                         };
                       }
@@ -347,7 +347,7 @@ export default function Admin(props) {
         </div>
 
         <hr />
-        <div class="pt-5">
+        <div class="pt-5 pb-5">
           {/* TITLE TEXT INPUT */}
           <div class="grid grid-cols-3 gap-5 px-12 justify-items-start">
             <p class="text-2xl">{t("Title Text")}:</p>
@@ -422,22 +422,39 @@ export default function Admin(props) {
             </div>
           </div>
         </div>
+        <hr />
         {/* ADMIN CONTROLS */}
-        <div class="flex flex-col">
-          <p class="text-2xl capitalize">{t("settings")}</p>
-          {/* Hide questions to players */}
-          <div class="flow flex-row space-x-5">
-            <p class="text-m normal-case">{t("Hide questions to players")}:</p>
-            <input
-              class="w-4 h-4 rounded"
-              checked={game.settings.hide_questions}
-              onChange={(e) => {
-                game.settings.hide_questions = e.target.checked;
-                props.setGame((prv) => ({ ...prv }));
-                send({ action: "data", data: game });
-              }}
-              type="checkbox"
-            ></input>
+        <div class="flex flex-col p-5">
+          <div>
+            <p class="text-xl capitalize">{t("settings")}:</p>
+            <hr class="w-24 p-1"/>
+          </div>
+          <div class="grid grid-cols-2">
+            {/* Hide questions to players */}
+            <div class="flex flex-col">
+              <div class="flex flex-row space-x-5 items-center">
+                <div>
+                  <p class="text-m normal-case">{t("Hide questions")}:</p>
+                </div>
+                <input
+                  class="w-4 h-4 rounded"
+                  checked={game.settings.hide_questions}
+                  onChange={(e) => {
+                    game.settings.hide_questions = e.target.checked;
+                    props.setGame((prv) => ({ ...prv }));
+                    send({ action: "data", data: game });
+                  }}
+                  type="checkbox"
+                ></input>
+              </div>
+              <div>
+                <p class="text-sm normal-case text-gray-500 italic">
+                  {t(
+                    'hide questions on the game window and player buzzer screens'
+                  )}
+                </p>
+              </div>
+            </div>
           </div>
         </div>
         {/* SHOW ERRORS TO ADMIN */}
@@ -634,9 +651,8 @@ export default function Admin(props) {
                 <div class=" text-white rounded border-4 grid grid-rows-4 grid-flow-col  p-3 mx-10 mt-5 gap-3 ">
                   {current_round.answers.map((x) => (
                     <div
-                      class={`${
-                        x.trig ? "bg-gray-600" : "bg-blue-600"
-                      } font-extrabold uppercase rounded border-2 text-2xl rounded `}
+                      class={`${x.trig ? "bg-gray-600" : "bg-blue-600"
+                        } font-extrabold uppercase rounded border-2 text-2xl rounded `}
                     >
                       <button
                         class="flex flex-row p-5 justify-center min-h-full items-center min-w-full"

--- a/components/admin.js
+++ b/components/admin.js
@@ -654,6 +654,9 @@ export default function Admin(props) {
                             game.point_tracker[game.round] =
                               game.point_tracker[game.round] -
                               x.pnt * current_round.multiply;
+                            if (game.point_tracker[game.round] < 0) {
+                              game.point_tracker[game.round] = 0;
+                            }
                             props.setGame((prv) => ({ ...prv }));
                           }
                           send({ action: "data", data: game });

--- a/components/final.js
+++ b/components/final.js
@@ -58,19 +58,23 @@ export default function Final(props) {
         <p class="text-3xl">{t("Fast Money")}</p>
       </div>
       <div
-        class="border-8 bg-blue-800 p-5 border-black rounded-3xl grid lg:grid-rows-4 lg:grid-flow-col gap-3 text-white "
+        class="border-8 bg-blue-800 p-5 border-black rounded-3xl grid lg:grid-flow-col gap-3 text-white "
         style={{}}
       >
-        <Answers
-          round={props.game.final_round}
-          hide={props.game.hide_first_round}
-        />
+        <div class="grid lg:grid-flow-row gap-3">
+          <Answers
+            round={props.game.final_round}
+            hide={props.game.hide_first_round}
+          />
+        </div>
         <div class="border-yellow-600 border-4 rounded-3xl bg-yellow-600 lg:hidden" />
-        <Answers
-          round={props.game.final_round_2}
-          hide={!props.game.is_final_second}
-        />
-      </div>
+        <div class="grid lg:grid-flow-row gap-3" >
+          <Answers
+            round={props.game.final_round_2}
+            hide={!props.game.is_final_second}
+          />
+        </div>
+        </div>
       <div class="my-3 flex flex-row justify-evenly items-center align-middle">
         {/* Timer */}
         <div class="bg-black inline-block p-2 rounded">

--- a/components/round.js
+++ b/components/round.js
@@ -58,7 +58,11 @@ export default function Round(props) {
         ) : null}
       </div>
       <div class="flex flex-row justify-center">
-        <p class="text-end sm:text-1xl text-2xl ">{round.question}</p>
+        {props.game.settings.hide_questions === false ? (
+          <p class="text-end sm:text-1xl text-2xl ">{round.question}</p>
+        ) : (
+          <></>
+        )}
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -4630,9 +4630,23 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001168",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-      "integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
+      "version": "1.0.30001489",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
+      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -32079,9 +32093,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001168",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
-      "integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
+      "version": "1.0.30001489",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
+      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/pages/api/ws.js
+++ b/pages/api/ws.js
@@ -81,7 +81,7 @@ const ioHandler = (req, res) => {
       registeredPlayers: {},
       buzzed: [],
       settings: {
-        hide_questions: false
+        hide_questions: true
       },
       teams: [
         {

--- a/pages/api/ws.js
+++ b/pages/api/ws.js
@@ -80,6 +80,9 @@ const ioHandler = (req, res) => {
     let game = {
       registeredPlayers: {},
       buzzed: [],
+      settings: {
+        hide_questions: false
+      },
       teams: [
         {
           name: "Team 1",

--- a/pages/game.js
+++ b/pages/game.js
@@ -106,10 +106,10 @@ export default function Game(props) {
       setInterval(() => {
         if (ws.current.readyState !== 1) {
           setError(
-            `lost connection to server refreshing in ${10 - refreshCounter}`
+            `lost connection to server refreshing in ${5 - refreshCounter}`
           );
           refreshCounter++;
-          if (refreshCounter >= 10) {
+          if (refreshCounter >= 5) {
             console.debug("game reload()");
             location.reload();
           }

--- a/pages/new.js
+++ b/pages/new.js
@@ -247,6 +247,24 @@ export default function CreateGame(props) {
               </div>
             </div>
           ))}
+          <div class="pt-5">
+            <button
+              onClick={() => {
+                game.final_round.push({
+                  question: `${t("question")} ${t("number", { count: game.final_round.length + 1 })}`,
+                  answers: [],
+                  selection: 0,
+                  points: 0,
+                  input: "",
+                  revealed: false,
+                });
+                setGame((prv) => ({ ...prv }));
+              }}
+              class="hover:shadow-md rounded-md bg-green-200 px-3 py-1 text-md"
+            >
+              {t("Question")} +
+            </button>
+          </div>
         </div>
       </div>
 

--- a/pages/new.js
+++ b/pages/new.js
@@ -14,7 +14,7 @@ export default function CreateGame(props) {
         multiply: "",
       },
     ],
-    final_round: Array.from(Array(4), (x, index) => {
+    final_round: Array.from(Array(5), (x, index) => {
       return {
         question: `${t("question")} ${t("number", { count: index + 1 })}`,
         answers: [],
@@ -191,7 +191,7 @@ export default function CreateGame(props) {
           </div>
         </div>
         <div class="border-2 p-3">
-          {game.final_round.map((q) => (
+          {game.final_round.map((q, qin) => (
             <div class="flex flex-col space-y-2 pt-5">
               <input
                 class="p-2 border-2"
@@ -242,8 +242,20 @@ export default function CreateGame(props) {
                   }}
                   class="hover:shadow-md rounded-md bg-green-200 px-3 py-1 text-md"
                 >
-                  +
+                  {t("Answer")} +
                 </button>
+                <div class="pt-5">
+                  <button
+                    onClick={() => {
+
+                      game.final_round.splice(qin, 1);
+                      setGame((prv) => ({ ...prv }));
+                    }}
+                    class="hover:shadow-md rounded-md bg-red-200 px-3 py-1 text-md"
+                  >
+                    {t("Question")} -
+                  </button>
+                </div>
               </div>
             </div>
           ))}


### PR DESCRIPTION
- Ability to hide questions for the players, so the admin can read the questions (on by default)
- Fast Money can now be any amount of rounds in game creator and game window (default to 5)
- admin can change the multiplier of the question points during the game