### PR TITLE
Create more space for q's on new page

### DIFF
--- a/pages/new.js
+++ b/pages/new.js
@@ -125,7 +125,7 @@ export default function CreateGame(props) {
               <div className="border-2 p-3 flex flex-col space-y-3">
                 <div className="flex space-x-3 flex-row">
                   <input
-                    className="p-2 border-2 bg-secondary-300 text-foreground"
+                    className="p-2 border-2 bg-secondary-300 text-foreground w-full"
                     value={r.question}
                     placeholder={t("question")}
                     onChange={(e) => {
@@ -136,7 +136,7 @@ export default function CreateGame(props) {
                   <input
                     type="number"
                     min="1"
-                    className="p-2 border-2 bg-secondary-300 text-foreground"
+                    className="p-2 border-2 bg-secondary-300 text-foreground w-15"
                     value={r.multiply}
                     placeholder={t("multiplier")}
                     onChange={(e) => {


### PR DESCRIPTION
As is, users may feel frustrated that they can't see their questions on the /new page.
![current-version-01-26-2024](https://github.com/joshzcold/Cold-Family-Feud/assets/18607666/7c531520-9a36-4589-9d2d-26cb3d53cd45)

I introduce new tailwind classes that allow the user to easily see what they have wrote.
![new-version-01-26-2024](https://github.com/joshzcold/Cold-Family-Feud/assets/18607666/3caf14be-19cb-4783-b57c-59a52a817f84)