### PR TITLE
[Bugfix]: Final Round Title

### DIFF
--- a/components/Admin/settings.js
+++ b/components/Admin/settings.js
@@ -83,11 +83,12 @@ function FinalRoundTitleChanger(props) {
       <p class="text-xl text-foreground">{t("Final Round Title")}:</p>
       <input
         class="border-4 rounded text-xl w-32 bg-secondary-500 text-foreground p-1 placeholder-secondary-900"
-        onl={debounce((e) => {
+        onChange={debounce((e) => {
           props.game.settings.final_round_title = e.target.value;
           props.setGame((prv) => ({ ...prv }));
           props.send({ action: "data", data: props.game });
         })}
+        defaultValue={props.game.settings.final_round_title}
         placeholder={t("fast money")}
       ></input>
     </div>


### PR DESCRIPTION
Input for entering final round title had irresponsive event listener and no way to accept initial value, fixed #77 