### PR TITLE
Fix cached logo

### DIFF
--- a/components/admin.js
+++ b/components/admin.js
@@ -273,7 +273,7 @@ function TitleLogoUpload(props) {
                     mimetype: mimetype,
                   });
                   props.setImageUploaded(file);
-                  props.game.settings.logo_url = `/rooms/${props.room}/logo.${mimetype}`;
+                  props.game.settings.logo_url = `/rooms/${props.room}/logo.${mimetype}?${new Date().getTime()}`;
                   props.setGame((prv) => ({ ...prv }));
                   props.send({ action: "data", data: props.game });
                 };

--- a/components/buzzer.js
+++ b/components/buzzer.js
@@ -218,7 +218,10 @@ export default function Buzzer(props) {
                   ) : (
                       <div>
                         {props.game.settings.logo_url ? (
-                          <img src={`${props.game.settings.logo_url}`} />
+                            <div className="mx-auto max-w-md w-full">
+                              <img className="w-full h-[300px] min-h-[200px] object-contain" src={`${props.game.settings.logo_url}`} 
+                              alt="Game logo"/>
+                            </div>
                         ) : (
                             <TitleLogo insert={props.game.title_text} />
                           )}
@@ -233,7 +236,10 @@ export default function Buzzer(props) {
         ) : (
             <>
               {props.game.settings.logo_url ? (
-                <img src={`${props.game.settings.logo_url}`} />
+                  <div className="mx-auto max-w-md w-full">
+                    <img className="w-full h-[300px] min-h-[200px] object-contain" src={`${props.game.settings.logo_url}`} 
+                    alt="Game logo"/>
+                  </div>
               ) : (
                   <TitleLogo insert={props.game.title_text} />
                 )}

--- a/components/title.js
+++ b/components/title.js
@@ -36,9 +36,9 @@ export default function Title(props) {
         className="align-middle inline-block"
       >
         <div className="flex flex-col space-y-10">
-          <div className="flex-grow">
+          <div className="flex-grow mx-auto">
             {props.game.settings.logo_url ? (
-              <img src={`${props.game.settings.logo_url}`} size={titleSize} />
+              <img className="w-full h-[300px] min-h-[200px] object-contain" src={`${props.game.settings.logo_url}`} size={titleSize} alt="Game logo"/>
             ) : (
                 <TitleLogo insert={props.game.title_text} size={titleSize} />
               )}


### PR DESCRIPTION
Fixes #75 Game logo not changing due to being cached

**Description:**
Due to the URL of game logo being the same even for different logos, the image would not update.

_The browser requests some content from the web server. If the content is not in the browser cache then it is retrieved directly from the web server. If the content was previously cached, the browser bypasses the server and loads the content directly from its cache._

**Changes made:**
- Added a param with the value of Date.now().getTime() to the end of the game logo source URL so it is unique on each upload
- Fixed some image styling as well (centering and size adjustments)