### PR TITLE
bug(csv) fix for csv "No Header" uncheck uses header

### DIFF
--- a/components/Admin/csv-loader.js
+++ b/components/Admin/csv-loader.js
@@ -82,7 +82,7 @@ function csvToColdFamilyFeudFormat(
   setError,
   send
 ) {
-  let headerOffSet = noHeader ? 1 : 0;
+  let headerOffSet = noHeader ? 0 : 1;
   let gameTemplate = {
     settings: {},
     rounds: [


### PR DESCRIPTION
swap the 0 and 1 when using headerOffSet in the game submit to match the visual representation of the csv parser in the ui