### PR TITLE
fix(game): eliminate off-by-one extra second in final round timer

### DIFF
--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -162,8 +162,9 @@ export default function GamePage() {
       } else if (json.action === "start_timer") {
         timerInterval = setInterval(() => {
           setTimer((prevTimer) => {
-            if (prevTimer > 0) {
-              return prevTimer - 1;
+            const nextTimer = prevTimer - 1;
+            if (nextTimer > 0) {
+              return nextTimer;
             } else {
               const audio = new Audio("try-again.mp3");
               audio.play();


### PR DESCRIPTION
The timer displays "0" for a full extra second before completing. A 20-second timer actually takes 21 seconds.