### PR TITLE
feat(ui): chromaKey theme

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,8 +12,8 @@ COPY --from=games . /src/games/
 COPY . .
 RUN mkdir -p /.cache/go-build /.cache/go-mod && \
     go mod download
-RUN go build .
-CMD ["air", "--build.cmd", "go build .", "--build.bin", "/src/Cold-Friendly-Feud"]
+RUN mkdir -p /src/tmp && go build -o /src/tmp/main .
+CMD ["air", "--build.cmd", "go build -o /src/tmp/main .", "--build.bin", "/src/tmp/main"]
 
 FROM base AS builder
 ENV CGO_ENABLED=1

--- a/e2e/tests/admin/settings.spec.ts
+++ b/e2e/tests/admin/settings.spec.ts
@@ -44,7 +44,7 @@ test("can switch themes", async () => {
   });
   await adminPage.themeSwitcherInput.selectOption({ index: 1 });
   await themeChanged;
-  await expect(spectator.page.locator("body")).toHaveClass("darkTheme bg-background");
+  await expect(spectator.page.locator("body")).toHaveClass("darkTheme bg-background game-screen");
 });
 
 test("can hide questions", async () => {

--- a/src/components/Admin/ThemeSwitcher.tsx
+++ b/src/components/Admin/ThemeSwitcher.tsx
@@ -40,6 +40,11 @@ export default function ThemeSwitcher({ game, setGame, send }: ThemeSwitcherProp
       fgcolor: "text-white",
       title: "red",
     },
+    chromaKey: {
+      bgcolor: "#00ff00",
+      fgcolor: "text-black",
+      title: "chroma key",
+    },
   };
 
   const handleThemeChange = (newTheme: string) => {

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -24,6 +24,7 @@ const ThemeProvider = ({ children }: ThemeProviderProps) => {
         slate: "slate",
         educational: "educational",
         red: "red",
+        chromaKey: "chromaKey",
       }}
       storageKey="theme"
     >

--- a/src/components/ToasterWithTheme.tsx
+++ b/src/components/ToasterWithTheme.tsx
@@ -11,6 +11,7 @@ function ToasterWithTheme({ ...props }) {
     slate: "dark",
     educational: "light",
     red: "dark",
+    chromaKey: "light",
   };
 
   const sonnerTheme = themeMap[theme as keyof typeof themeMap] || "light";

--- a/src/global.css
+++ b/src/global.css
@@ -36,3 +36,8 @@
 .font-oswald {
   font-family: "Oswald";
 }
+
+body.game-screen.chromaKey,
+.game-screen.chromaKey {
+  background-color: #00ff00 !important;
+}

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -37,6 +37,17 @@ export default function GamePage() {
   }, [game?.is_final_round, game?.is_final_second, game?.final_round_timers]);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const themeClass = game?.settings?.theme ?? "default";
+    document.body.className = `${themeClass} bg-background game-screen`;
+
+    return () => {
+      document.body.classList.remove("game-screen");
+    };
+  }, [game?.settings?.theme]);
+
+  useEffect(() => {
     ws.current = new WebSocket(`wss://${window.location.host}/api/ws`);
     ws.current.onopen = function () {
       console.log("game connected to server");
@@ -256,6 +267,8 @@ export default function GamePage() {
   }, []);
 
   if (game?.teams != null) {
+    const activeTheme = game?.settings?.theme ?? "default";
+
     let gameSession;
     if (game.title) {
       gameSession = <TitlePage game={game} />;
@@ -290,9 +303,6 @@ export default function GamePage() {
       }
     }
 
-    if (typeof window !== "undefined") {
-      document.body.className = (game?.settings?.theme ?? "default") + " bg-background";
-    }
     return (
       <>
         {!isHost ? (
@@ -310,7 +320,7 @@ export default function GamePage() {
           </div>
         ) : null}
         <StrikeOverlay count={showMistake} />
-        <div className={`${game?.settings?.theme ?? "default"} min-h-screen`}>
+        <div className={`${activeTheme} game-screen min-h-screen bg-background`}>
           <div className="">{gameSession}</div>
         </div>
         <BuzzerPopup buzzed={buzzed} />


### PR DESCRIPTION
Added a chroma key theme that sets GAME SCREEN ONLY to lime (#00ff00)

This enables streamers to easily use the default styling but replace the background with a background of their choice.
This brings up the idea of potentially using a background setter similar to the logo setter, but streamers want the background to be transparent for scene purposes