### PR TITLE
fix(ui): revert to zoom in ScaleToFit

### DIFF
--- a/src/components/ScaleToFit.tsx
+++ b/src/components/ScaleToFit.tsx
@@ -21,9 +21,8 @@ export default function ScaleToFit({ children, className = "", contain = false }
     if (!container || !content) return;
 
     const update = () => {
-      // Reset transform so measurements reflect natural content size.
-      content.style.transform = "scale(1)";
-      content.style.transformOrigin = "center center";
+      // Reset zoom to measure natural dimensions
+      content.style.zoom = "1";
 
       const naturalW = content.scrollWidth;
       if (naturalW === 0) return;
@@ -35,14 +34,15 @@ export default function ScaleToFit({ children, className = "", contain = false }
         scale = Math.min(scale, container.clientHeight / naturalH);
       }
 
-      content.style.transform = `scale(${scale})`;
+      content.style.zoom = String(scale);
     };
 
     update();
     const ro = new ResizeObserver(update);
     ro.observe(container);
+    ro.observe(content);
     return () => ro.disconnect();
-  }, [contain, children]);
+  }, [contain]);
 
   return (
     <div ref={containerRef} className={className}>


### PR DESCRIPTION
Reverting the `ScaleToFit` changes from #254, which came from the Copilot review.

I find this interesting, so let me take a moment to address each thing Copilot said.

---

> `ScaleToFit` references `React.ReactNode` but React isn't imported... This will fail type-checking

I believe `@types/react` exposes `React` as a global. Explicit import is just about preference.

> Using `style.zoom` for scaling is non-standard and won't work in Firefox.

Firefox supports `zoom` since 2024, and caniuse currently reports ~97% global support. And they are fundamentally different: `zoom` changes the element's actual size (affecting flow), while `transform` just adds a visual effect.

I can observe issues like: scrollbars appearing when shrinking the window, wonky layout when rotating mobile devices, and not as crisp pixel-wise. But there could be other side effects not immediately obvious.

Tbf, it did mention compensating the layout with a wrapper (hacky way to emulate `zoom`'s behavior), but that part wasn't implemented.

> `ResizeObserver` is observing `content`... The `update()` mutation can trigger the observer again and cause a loop.

`update()` is idempotent, as in the output doesn't change when repeated. And observing `content` could catch useful things like font/image load and reflow.

---

Each of these sounded reasonable and could easily convince a careful reviewer, but none held up (IMO). They even led to real regressions. The point is, you can't blindly trust them.

Don't get me wrong, I use agents in my own workflow and make mistakes. But while they give me great leverage, I find that the quality of the output is tightly coupled to how involved and critical I'm being.
