### PR TITLE
feat(dev): Use http in local dev/container upgrade ws in prod

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -23,7 +23,6 @@ COPY ./games/ /app/games/
 COPY --from=back-end-builder /src/Cold-Friendly-Feud /app/Cold-Friendly-Feud
 COPY --from=front-end-builder /app/node_modules/ /app/node_modules/
 COPY docker/allinone/nginx.conf /etc/nginx/nginx.conf
-COPY dev/cert/ /etc/nginx/cert/
 COPY . /app/
 RUN npm run build
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -56,12 +56,15 @@ For Windows users, we recommend using WSL.
 You might need to configure Windows firewall to allow WSL network access:
 ```powershell
 # Add outbound rules
-netsh advfirewall firewall add rule name="WSL2 HTTPS Out" dir=out action=allow protocol=TCP localport=443
+# netsh advfirewall firewall add rule name="WSL2 HTTPS Out" dir=out action=allow protocol=TCP localport=443
 netsh advfirewall firewall add rule name="WSL2 HTTP Out" dir=out action=allow protocol=TCP localport=80
+
 # Add inbound rules
-netsh advfirewall firewall add rule name="WSL2 HTTPS" dir=in action=allow protocol=TCP localport=443
+# netsh advfirewall firewall add rule name="WSL2 HTTPS" dir=in action=allow protocol=TCP localport=443
 netsh advfirewall firewall add rule name="WSL2 HTTP" dir=in action=allow protocol=TCP localport=80
 ```
+
+If you opt into local HTTPS, also allow port 443.
 
 ### Linux Setup
 
@@ -74,7 +77,7 @@ Install dependencies
    ```bash
    make dev
    ```
-4. Access the application at [localhost](https://localhost/)
+4. Access the application at [localhost](http://localhost/)
 
 ## Running development
 The stack consists of:
@@ -89,7 +92,7 @@ The development environment is managed through a Makefile. Key commands include:
 - `make dev-background`: Same as `make dev`, but detaches
 - `make dev-down`: Stops/removes the development stack
 
-Access the application at [localhost/](https://localhost/)
+Access the application at [localhost/](http://localhost/)
 
 The compose files should automatically be selected by the Makefile, but you can:
 - check out the [Linux version](../docker/docker-compose.yaml) if on Linux or Macos

--- a/docker/allinone/nginx.conf
+++ b/docker/allinone/nginx.conf
@@ -45,14 +45,8 @@ http {
     keepalive_timeout  75 20;
 
     server {
-        listen        443 ssl default_server;
+        listen        80 default_server;
         server_name   famf.app;
-        ssl_certificate     /etc/nginx/cert/localhost.crt;
-        ssl_certificate_key /etc/nginx/cert/localhost.key;
-        ssl_session_timeout  		5m;
-        ssl_protocols  			TLSv1.2 TLSv1.3;
-        ssl_ciphers         ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-        ssl_prefer_server_ciphers   	on;
 
         access_log   /var/log/nginx.access_log  main;
 

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -37,13 +37,12 @@ services:
   proxy:
     image: nginx:1.27-alpine
     ports:
-      - 443:443
+      - 80:80
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ../dev/cert/:/etc/nginx/cert/
     healthcheck:
-      # -k flag allows self-signed certificates in development
-      test: ['CMD', 'curl', '-f', '-k', 'https://localhost:443']
+      test: ['CMD', 'curl', '-f', 'http://localhost:80']
       interval: 5s
       timeout: 3s
       retries: 3

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -40,7 +40,6 @@ services:
       - 80:80
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ../dev/cert/:/etc/nginx/cert/
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:80']
       interval: 5s

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,10 +29,9 @@ services:
   proxy:
     image: nginx:1.27-alpine
     ports:
-      - 443:443
+      - 80:80
     healthcheck:
-      # -k flag allows self-signed certificates in development
-      test: ['CMD', 'curl', '-f', '-k', 'https://localhost:443']
+      test: ['CMD', 'curl', '-f', 'http://localhost:80']
       interval: 5s
       timeout: 3s
       retries: 3

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -45,14 +45,8 @@ http {
     keepalive_timeout  75 20;
 
     server {
-        listen        443 ssl default_server;
+        listen        80 default_server;
         server_name   famf.app;
-        ssl_certificate     /etc/nginx/cert/localhost.crt;
-        ssl_certificate_key /etc/nginx/cert/localhost.key;
-        ssl_session_timeout  		5m;
-        ssl_protocols  			TLSv1.2 TLSv1.3;
-        ssl_ciphers         ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-        ssl_prefer_server_ciphers   	on;
 
         access_log   /var/log/nginx.access_log  main;
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -29,7 +29,7 @@ module.exports = defineConfig({
     /* Ignore ssl for local dev */
     ignoreHTTPSErrors: true,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "https://127.0.0.1",
+    baseURL: "http://127.0.0.1",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 <div align="center">
 <img src="./public/title.png" alt="title logo" width="200"/>
-  
+
 This app is currently available at ➡ https://famf.app
 
 </div>
@@ -36,16 +36,28 @@ Features:
 To run a local instance of the application using the prebuilt "all in one" image.
 
 ```sh
-    sudo docker run -p 443:443 -ti ghcr.io/joshzcold/famf-allinone:latest
+    sudo docker run -p 80:80 -ti ghcr.io/joshzcold/famf-allinone:latest
 ```
 
 go to
 
-https://localhost/
+http://localhost/
 
 Click on the "Host" button to go to the admin console
 
 Players can join your game by entering in the supplied room code.
+
+### HTTPS (optional)
+
+<details>
+Local HTTPS is optional. For most local or LAN setups, HTTP keeps development friction low and avoids self-signed certificate warnings.
+
+If you want HTTPS locally (for example, to mirror production or test secure contexts):
+
+- Run a proxy that listens on `443` with TLS and use `https://localhost/`.
+- You'll need a trusted local certificate (self-signed certs may be blocked by some browsers or mobile devices).
+- WebSockets will automatically use `wss://` when the page is served over HTTPS.
+</details>
 
 ### Screen Share Audio Linux
 

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,8 @@ Players can join your game by entering in the supplied room code.
 ### HTTPS (optional)
 
 <details>
+<summary>Enable local HTTPS</summary>
+
 Local HTTPS is optional. For most local or LAN setups, HTTP keeps development friction low and avoids self-signed certificate warnings.
 
 If you want HTTPS locally (for example, to mirror production or test secure contexts):

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,3 +1,4 @@
 export { handleCsvFile, handleJsonFile, isValidFileType, validateGameData } from "./files";
 export { debounce } from "./debounce";
 export { getTeamDisplayName } from "./team-display";
+export { getWebSocketUrl } from "./ws";

--- a/src/lib/utils/ws.ts
+++ b/src/lib/utils/ws.ts
@@ -1,0 +1,9 @@
+export const getWebSocketUrl = (path = "/api/ws") => {
+  if (typeof window === "undefined") {
+    return `ws://localhost${path}`;
+  }
+
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+
+  return `${protocol}://${window.location.host}${path}`;
+};

--- a/src/pages/buzzers.tsx
+++ b/src/pages/buzzers.tsx
@@ -6,6 +6,7 @@ import cookieCutter from "cookie-cutter";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { getWebSocketUrl } from "@/lib/utils";
 import NoSession from "../components/ui/NoSession";
 
 export default function BuzzersPage() {
@@ -31,7 +32,7 @@ export default function BuzzersPage() {
   }
 
   useEffect(() => {
-    ws.current = new WebSocket(`wss://${window.location.host}/api/ws`);
+    ws.current = new WebSocket(getWebSocketUrl());
     ws.current.onopen = function () {
       console.log("game connected to server");
       const session = cookieCutter.get("session");

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -13,6 +13,7 @@ import cookieCutter from "cookie-cutter";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { getWebSocketUrl } from "@/lib/utils";
 import NoSession from "../components/ui/NoSession";
 
 let timerInterval: NodeJS.Timeout | null = null;
@@ -76,7 +77,7 @@ export default function GamePage() {
   }, [game?.settings?.theme]);
 
   useEffect(() => {
-    ws.current = new WebSocket(`wss://${window.location.host}/api/ws`);
+    ws.current = new WebSocket(getWebSocketUrl());
     ws.current.onopen = function () {
       console.log("game connected to server");
       const session = cookieCutter.get("session");

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,7 @@ import { Game, WSEvent } from "@/types/game";
 // @ts-expect-error: not sure if cookie-cutter is typed
 import cookieCutter from "cookie-cutter";
 import { toast } from "sonner";
+import { getWebSocketUrl } from "@/lib/utils";
 
 interface GameContextType {
   roomCode: string;
@@ -74,7 +75,7 @@ export default function Home() {
   }
 
   function startWsConnection() {
-    ws.current = new WebSocket(`wss://${window.location.host}/api/ws`);
+    ws.current = new WebSocket(getWebSocketUrl());
     ws.current.onopen = function () {
       console.debug("game connected to server", ws.current);
       if (ws.current) {


### PR DESCRIPTION
frontend detects http vs. https and uses secure websockets only when needed. This allows local launches of the game can be on http with no friction of self signed certificates

fixes: #106