### PR TITLE
fix: E2E test playwright dependency install fails

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -43,6 +43,7 @@ jobs:
   test:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.js
@@ -54,13 +55,22 @@ jobs:
         run: |
           npm ci
           cd e2e
-      - name: Install Playwright browsers
+      - name: Install Playwright system dependencies
+        timeout-minutes: 20
         run: |
-          cd e2e
-          npx playwright install --with-deps
+          npx playwright install-deps chromium
+      - name: Install Playwright browser
+        timeout-minutes: 20
+        run: |
+          npx playwright install --only-shell chromium
       - name: Run e2e tests
+        timeout-minutes: 20
         run: |
           make e2e
+      - name: Stop e2e services
+        if: always()
+        run: |
+          make dev-down || true
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -59,10 +59,9 @@ jobs:
         timeout-minutes: 20
         run: |
           npx playwright install-deps chromium
-      - name: Install Playwright browser
-        timeout-minutes: 20
+      - name: Verify Chrome browser
         run: |
-          npx playwright install --only-shell chromium
+          google-chrome --version
       - name: Run e2e tests
         timeout-minutes: 20
         run: |

--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,15 @@ build-allinone:
 
 build-backend:
 	set -x
-	cd backend
 	docker build \
-		--build-context=games=../games \
-		-t ${docker_registry}/famf-server:latest .
+		--build-context=games=$(CURDIR)/games \
+		-t ${docker_registry}/famf-server:latest ./backend
 
 build-backend-dev:
 	set -x
-	cd backend
 	docker build \
-		--build-context=games=../games \
-		-t ${docker_registry}/famf-server:dev --target dev .
+		--build-context=games=$(CURDIR)/games \
+		-t ${docker_registry}/famf-server:dev --target dev ./backend
 		
 build: build-frontend build-backend build-allinone
 
@@ -49,10 +47,7 @@ dev: build-dev
 	docker compose -p famf -f ./docker/docker-compose-dev.yaml up
 
 dev-background: build-dev
-	docker compose -p famf -f ./docker/docker-compose-dev.yaml up -d --wait --wait-timeout 120 || {
-		docker compose -p famf logs
-		exit 1
-	}
+	docker compose -p famf -f ./docker/docker-compose-dev.yaml up -d --wait --wait-timeout 120 || (docker compose -p famf logs && exit 1)
 
 # Teardown
 dev-down:
@@ -63,29 +58,13 @@ dev-down-clean:
 	docker compose -p famf -f ./docker/docker-compose-dev.yaml down -v
 
 e2e: dev-background
-	npm install
-	cd e2e
-	npx playwright test
-	status=$$?
-	cd -
-	$(MAKE) dev-down
-	exit $$status
+	bash -c 'set -e; trap "docker compose -p famf -f $(CURDIR)/docker/docker-compose-dev.yaml down" EXIT; npm ci; cd e2e; npx playwright test --config playwright.config.ts'
 
 e2e-ui: dev-background
-	trap 'make dev-down' EXIT
-	npm install
-	(
-		cd e2e
-		npx playwright test --ui
-	)
-	$(MAKE) dev-down
+	bash -c 'set -e; trap "docker compose -p famf -f $(CURDIR)/docker/docker-compose-dev.yaml down" EXIT; npm install; cd e2e; npx playwright test --ui'
 
 e2e-prod:
-	cd e2e
-	npm install
-	npx playwright test --ui --config playwright-prod.config.js
+	cd e2e && npm install && npx playwright test --ui --config playwright-prod.config.js
 
 e2e-dev:
-	cd e2e
-	npm install
-	npx playwright test --ui --config playwright-dev.config.js
+	cd e2e && npm install && npx playwright test --ui --config playwright-dev.config.js

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -49,7 +49,10 @@ module.exports = defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        channel: process.env.CI ? "chrome" : undefined,
+      },
     },
 
     // {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -14,6 +14,8 @@ module.exports = defineConfig({
   testDir: "./tests",
   /* 60s timeout (initial build takes 60s) */
   timeout: 60000,
+  /* Bound the whole suite so CI fails fast instead of waiting for the job limit. */
+  globalTimeout: process.env.CI ? 10 * 60 * 1000 : undefined,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
This PR fixes the E2E workflow hanging until GitHub Actions cancels it.

The issue was not the tests themselves. The job was getting stuck before `make e2e` ever ran. The logs showed Playwright finished downloading the browser archive, but then the Playwright install command never finished. This happened first with `npx playwright install --with-deps`, and then still happened with `npx playwright install --only-shell chromium`. So the issue was Playwright’s browser install step hanging after the download completed.

The test config only runs Chromium, so we no longer need to install the full Playwright browser set in CI.

**What Changed**:

- Removed the Playwright browser download step from CI.
- Updated CI to use the Chrome browser already installed on the GitHub runner.
- Added a `google-chrome --version` step to verify successful browser installation.
- Kept `npx playwright install-deps chromium` so the needed Linux browser dependencies are still present.
- Updated Playwright config to use `channel: "chrome"` only in CI.
- Added timeouts so E2E failures do not sit until the GitHub 6 hour limit.
- Added an always-run cleanup step in CI to stop Docker services if something fails.
- Updated `make e2e` so Docker Compose cleanup runs reliably after tests.
- Made the backend Docker build context more explicit instead of relying on `cd backend`.
- Added a Playwright global timeout in CI as a backup safety net.

**Justification**:

The failing command was not slowly downloading Chromium. The download reached `100%` quickly, then the install process hung until the step timeout.

Using the runner’s installed Chrome avoids the Playwright-managed browser install path entirely while still running the same Chromium-based E2E suite.

> Note: the full E2E run still had 2 flaky tests locally, but the command completed instead of hanging and Docker cleanup worked.